### PR TITLE
Fix typos in class 2 exercises & tests

### DIFF
--- a/class2/exercises/lib/exercise9.ex
+++ b/class2/exercises/lib/exercise9.ex
@@ -1,8 +1,8 @@
 defmodule Exercises.Exercise9 do
   @doc """
    Spawn :server process, which endlessly handles messages.
-   Sever should pass messages to :test process.
-   When server gets exit singal, then it should send :handle_exit message to :test process.
+   Server should pass messages to :test process.
+   When server gets exit signal, then it should send :handle_exit message to :test process.
    Server should send :nothing_todo message to :test process after 500ms inactivity.
    Spawn unregistered client process which sends to server 10 messages
 

--- a/class2/exercises/test/exercises/exercise3_test.exs
+++ b/class2/exercises/test/exercises/exercise3_test.exs
@@ -2,7 +2,7 @@ defmodule Exercises.Exercise3Test do
   use ExUnit.Case, async: false
 
   @tag :"test3.1"
-  test "Should return pid, register it under :hello name, handle msg and termiante" do
+  test "Should return pid, register it under :hello name, handle msg and terminate" do
     pid = Exercises.Exercise3.wait_and_print()
     assert is_pid(pid) == true, "Function should return pid"
     Process.sleep(300)

--- a/class2/exercises/test/exercises/exercise4_test.exs
+++ b/class2/exercises/test/exercises/exercise4_test.exs
@@ -2,7 +2,7 @@ defmodule Exercises.Exercise4Test do
   use ExUnit.Case, async: false
 
   @tag :test4
-  test "Should send :timeout messgae after 500ms" do
+  test "Should send :timeout message after 500ms" do
     Process.register(self(), :test)
     pid = Exercises.Exercise4.send_timeout()
     assert is_pid(pid) == true, "Function should return pid"


### PR DESCRIPTION
# Also, exercise 6 description could be more verbose
Exercise 6 description is a little bit misleading.

```
 - spawn a new unregistered process, 
      - wait 1500ms 
      - print ":world is alive!" if process :world is alive
      - print ":world is dead!" otherwise
   - explain why :world process is alive or dead
```

Test expects to `send` `":world is alive/dead!"` to `:test` process, instead of printing